### PR TITLE
Fix spelling and some grammar issues with README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Install breach buster
 
     $ pip install breach_buster
 
-Open your settings.py file in an editor and modifiy it to
+Open your settings.py file in an editor and modify it to
 
     MIDDLEWARE_CLASSES = (
         'django.middleware.gzip.GZipMiddleware',
@@ -28,12 +28,12 @@ Detailed Explanation
 --------------------
 
 BREACH is a side channel attack that takes advantage of a well known
-characteristic of data compression: files that are self similar will
-tend to be smaller.   This is used to 
+characteristic of data compression: files that are similar to each
+other will tend to be smaller.
 
-Lets take a look at what that means.  In the code below we feed two
-sentences to the zlib compressor.  Both sentences are the same length,
-except the latter replaces dog with fox, a string that was already
+Let's take a look at what that means.  In the code below we feed two
+sentences to the zlib compressor. Both sentences are the same length,
+except that the latter replaces dog with fox, a string that was already
 used.
 
     >>> import zlib
@@ -45,14 +45,14 @@ used.
 
 
 The later compresses to 3 bytes less than the former.  You might be
-thinking "well that's a bad example, the so called compression made
+thinking "That's a bad example, the so called compression made
 the file larger". True, but the same applies to larger files as well.
-Lets try again with a longer example.
+Let's try again with a longer example.
 
-Here we download a copy of the Wikipedia article on the the Communist
-Manifesto.  To prepare two files that are different we append to one
-the word "Proletariat" and to the other the slightless less like to
-appear "Adirondacks".
+Here we download a copy of the Wikipedia article on [the Communist
+Manifesto](https://en.wikipedia.org/wiki/The_Communist_Manifesto).  To prepare
+two files that are different, we append the word "Proletariat" to one file and
+to "Adirondacks" (less likely to appear) to the other.
 
     >>> import zlib, urllib2 
     >>> prose = urllib2.urlopen("http://www.marxists.org/archive/marx/works/1848/communist-manifesto/ch01.htm").read()
@@ -70,45 +70,45 @@ appear "Adirondacks".
     >>> 
 
 
-We can see the file with Proletariat added is somewhat smaller than
+We can see the file with Proletariat added is smaller than
 the file with Adriondacks added.
 
 So how does BREACH take advantage of this?
 
-It is assumed an attacker using BREACH has three non-trivial to obtain abilities.  
+It is assumed an attacker using BREACH has three abilities.  
 
 First, we assume the attacker has the ability to monitor the victim's
-internet connection.  This can happen in many ways.  The attacker can
-be sniffing the victim's local wifi or ethernet connection, they can
-work for the victim's ISP.  All they need to do is be able to see the
-data common back well enough to measure the length of each response. 
+internet connection. This can happen in many ways. The attacker can
+sniff the victim's local wifi or ethernet connection, or they might
+work for the victim's ISP.  All they need to do is measure the length of
+each response returned to the victim's machine.
 
-Secondly we assume the attacker has some way of coersing the victims
-browser to load urls at will.  We assume this doesn't mean the attacker can
-see the content that comes back - if the attacker could this entire
-exercise would be moot - they only need to log in as themselves.   
+Secondly, we assume the attacker has some way of coercing the victim's
+browser to load URLs at will.  We assume this does not mean the attacker
+can see the content that comes back - if so, this entire exercise would
+be moot.   
 
 Third, the page must be willing to return information passed to it by
 the client.  This entire attack depends on the ability to inject data
 into the HTTP content.  Normally this isn't too hard - perhaps there
-is a form field the web server will happily fill for you?  Name or
+is a form field the web server will happily fill for you? Your name or
 something?
 
-It i important to stress that the attacker should know what they are
-looking for.  This attack cannot give us the contents of the page, it
-can only betray a small peice.  If the attacker has already visited
+It is important to stress that the attacker must know what they are
+looking for. This attack cannot give us the contents of the page; it
+can only betray a small piece.  If the attacker has already visited
 this site and knows the secret to be in a field called
-`"uber_secret_api_key=<8 digit hexidecimal number>"` then this attack
-will work.  If we've never seen this page because we cannot coerse the
-browser to make a copy for us sans the secrets we are looking for,
-this attack won't work.
+`"uber_secret_api_key=<8 digit hexadecimal number>"`, then this attack
+will work. Otherwise, the attacker cannot coerce the browser to make a
+copy of the page without the secrets they are looking for.
 
-There are all sorts of ways we could achive these three requirements.
-You could intercept non-encrytped web traffic and inject a little HTML
-that looks something like this: `<img
-href="http://victimsbank.com/...">` You could setup a transparent web
-proxy in their emplyoer's data cabinet.  Or you could simply email
-them a link to a website with pictures of pretty undressed people.
+There are multiple ways to achieve the three requirements.
+  * The attacker could intercept non-encrypted web traffic and inject some
+    HTML: `<img href="http://victimsbank.com/...">`
+  * The attacker could setup a transparent web
+    proxy in their employer's data cabinet.
+  * The attacker could email the target a link to a website with
+    pictures of pretty undressed people.
 
 Nothing I describe here is too hard to come by for a moderately
 sophisticated geek.  And with this in mind we're going to build a
@@ -118,42 +118,40 @@ BREACH attack.
 Let's Breach
 ------------
 
-Before we do, lets talk about what we won't be doing.  This isn't a
-lesson on coering browsers to send urls or sniffing Wifi so we're
-going to cheat.  This example won't use SSL or a browser.  Its a
-demonstration, an educational tool, not a fully weaponized attack
+Before we do, let's talk about what we won't be doing.  This isn't a
+lesson on coercing browsers to send URLs or sniffing Wifi, so we're
+going to cheat. This example won't use SSL or a browser. It's a
+demonstration, an educational tool, and not a fully weaponized attack
 platform for script kiddies.
 
-Now there are a few more requrements to conducting a successful breach
-attack that need to be mentioned.  First it helps to understand what
-you are looking for --- breach won't give you.
-
-Lets install breach_buster.
+Let's install breach_buster.
 
 `$ pip install breach_buster`
 
-Now in one window lets open the breach buster web server.  It has two
+Now in one window let's open the breach buster web server.  It has two
 pages, /good and /bad.  Each contains a CSRF key called "CSRF" that
 refers to a 16 digit sequence of lower case letters or underscores.
 Both urls use gzip content encoding; the /bad emulates django's gzip
-content conciding strategy.  /good uses breach_buster's content
+content coinciding strategy.  /good uses breach_buster's content
 encoding.
 
-Lets run the breach_buster_demo_server and put it in the background:
+Let's run the breach_buster_demo_server and put it in the background:
 
 `$ breach_buster_demo_server 127.0.0.1:8080 &`
 
 This server is also very friendly; the returned content will call you
-by name if provided a parameter called "name."  This is how we inject content into the site.
+by name if provided a parameter called "name."  This is how we inject
+content into the site.
 
-Open a window to your python interepter and lets start writing a bit of code. 
+Open a window to your python interpreter and let's start writing a bit
+of code. 
 
     >>> import urllib2 
     >>> def length(name):
     ...     return len(urllib2.urlopen('http://127.0.0.1:8080/bad?name=' + name).read())
     ...
 
-The breach_buster_demo_server and urllib2 both have conveniennt bugs
+The breach_buster_demo_server and urllib2 both have convenient bugs
 for this project.  breach_buster_demo_server doesn't check if the
 client supports gzip encoding before using it.  urllib2 doesn't
 support gzip encoding.  The call to .read returns the compressed data
@@ -162,7 +160,7 @@ content directly off the wire.
     >>> length('')
     883
 
-Lets try adding a few strings.
+Let's try adding a few strings.
 
     >>> length('foobar')
     887
@@ -177,7 +175,7 @@ We expect `do_something?CSRF=` to add relatively little data
 proportional to the length of the added string because this string
 already exists in the output.
 
-Lets try all possiable combinations of first letters:
+Let's try all possible combinations of first letters:
 
     >>> for letter in '0123456789abcdef': print letter, length('do_something?CSRF=' + letter)
     ...
@@ -198,7 +196,7 @@ Lets try all possiable combinations of first letters:
     e 886
     f 886
 
-We can see that e and f are excellent consideration.  Lets try adding another letter to both e and f.
+We can see that e and f decrease the size of the string.  Let's try adding another letter to both e and f.
 
     >>> for l1 in 'ef':
     ...     for l2 in '01234566789abcdef': print l1+l2, length('do_something?CSRF=' + l1 + l2)                                                                        
@@ -230,7 +228,7 @@ We can see that e and f are excellent consideration.  Lets try adding another le
     fe 886
     ff 887
 
-f6 and fe are both excellent ... we could keep on going manually, its
+f6 and fe are both excellent ... we could keep on going manually, it's
 much easier to automate this search.  A script to do this for you has
 been provided in scripts/breach_buster_demo_client
 
@@ -255,15 +253,15 @@ in an interactive session.
 
 Zlib compression, the underlying library behind gzip, is used for more
 than file compression.  Assuming the data stream you work with is
-compressiable there will be far fewer characters coming oeut of the
-compresssor than going in.  Gzip reads some data, processes this data,
+compressible there will be far fewer characters coming out of the
+compressor than going in.  Gzip reads some data, processes this data,
 and when it has accumulated enough, outputs the same.  Sometimes bytes
-will be read without any bytes being out - by definition, if the file
+will be read without any bytes being output - by definition, if the file
 is being compressed this has to happen because you have too few output
 bytes to have one correspond for each and every input byte.
 
 This can become a problem for command line interaction.  Let us
-consider as a our strawman case Unix's passwd command.  The inteaction
+consider as a our strawman case Unix's passwd command.  The interaction
 looks something like this:
 
     Old password: secret
@@ -271,20 +269,20 @@ looks something like this:
     New password (again): soupersekret
 
 Within a zlib compressor this entire chunk of text might compress to a
-single offset to a previously occuring sample.  The ideal behaivor for
+single offset to a previously occurring sample.  The ideal behavior for
 the compressor is to hold onto text until it has the best match it can
 find.
 
-But from a useability perspective this is horrid ... if old password
+But from a usability perspective this is horrid ... if the old password
 is being sequestered inside the compressor to see if it might match
 something better later on, you, as a user would never know what the
-ssystem expects of you.
+system expects.
 
 The zlib library has a function called "flush."  Flush instructs the
-compressor to spit out whatever is nessesary to ensure the receiver is
+compressor to spit out whatever is necessary to ensure the receiver is
 able to receive and decode all of the date that has been sent to the
 compressor so far.  This function instructs the zlib library to do so
-even if the resulting output is compressed less efficently than it
+even if the resulting output is compressed less efficiently than it
 otherwise would have been.  This usually increases the size of the
 resulting data stream by a small amount.  
 


### PR DESCRIPTION
Fixes various spelling errors and rearranges some sentences in order to
make the README more grammatically sound.
