### PR TITLE
Python3 install compatibility

### DIFF
--- a/breach_buster/middleware/gzip.py
+++ b/breach_buster/middleware/gzip.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import re
+import six
 from gzip import GzipFile
 from random import Random
 from six import BytesIO, StringIO
@@ -65,7 +66,7 @@ def compress_string(s):
     else:
         avg_block_size = 1.0 / AVERAGE_SPAN_BETWEEN_FLUSHES
 
-    s = StringIO(s)
+    s = StringIO(s) if isinstance(s, six.text_type) else BytesIO(s)
     zbuf = BytesIO()
     zfile = GzipFile(mode='wb', compresslevel=6, fileobj=zbuf)
     chunk = s.read(MIN_INTERFLUSH_INTERVAL + int(rnd.expovariate(avg_block_size)))

--- a/breach_buster/middleware/gzip.py
+++ b/breach_buster/middleware/gzip.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import
 import re
 from gzip import GzipFile
 from random import Random
-from io import BytesIO
-from StringIO import StringIO
+from six import BytesIO, StringIO
 
 
 AVERAGE_SPAN_BETWEEN_FLUSHES = 512

--- a/breach_buster/middleware/gzip.py
+++ b/breach_buster/middleware/gzip.py
@@ -95,7 +95,7 @@ def compress_sequence(sequence):
     rnd = None
     for item in sequence:
         if rnd is None:
-            rnd = Random(0)
+            rnd = Random(hash(item))
             count = int(rnd.expovariate(avg_block_size))
         chunking_buf = BytesIO(item)
         chunk = chunking_buf.read(count)
@@ -127,6 +127,7 @@ def compress_sequence(sequence):
         
     zfile.close()
     yield buf.read()
+
 
 class GZipMiddleware(object):
     """

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     include_package_data=True,
     classifiers=[],
     scripts=['scripts/breach_buster_demo_client','scripts/breach_buster_demo_server'], 
-    install_requires=[
+    tests_require=[
         'web.py'
-        ]
-    )
+    ]
+)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup
 
 setup(
     name='breach_buster',
-    version='0.0.3',
+    version='0.0.4',
     author='Adam DePrince',
     author_email='adeprince@nypublicradio.org',
     description='BREACH resistant gzip middleware for Django',

--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,12 @@ setup(
         'breach_buster/middleware/gzip',
         'breach_buster/examples/__init__',
         'breach_buster/examples/demo_server',
-        ],
+    ],
     packages=['breach_buster',],
     zip_safe=True,
     license='GPLv3',
     include_package_data=True,
     classifiers=[],
-    scripts=['scripts/breach_buster_demo_client','scripts/breach_buster_demo_server'], 
     tests_require=[
         'web.py'
     ]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,10 @@ setup(
     license='GPLv3',
     include_package_data=True,
     classifiers=[],
+    install_requires=[
+        'six',
+    ],
     tests_require=[
-        'web.py'
+        'web.py',
     ]
 )


### PR DESCRIPTION
Package cannot be installed in Python3 since web.py does not support Python3. Moving the web.py requirement as tests requirement allows to install package in Python3 and in Python3 users can run `setup.py test` to install test requires to be able to run demo/test server.

Also removed scripts from the `setup.py` as they are not in the code.
