### PR TITLE
Inherit from MiddlewareMixin

### DIFF
--- a/breach_buster/middleware/gzip.py
+++ b/breach_buster/middleware/gzip.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import re
+from django.utils.deprecation import MiddlewareMixin
 from gzip import GzipFile
 from random import Random
 from io import BytesIO
@@ -128,7 +129,7 @@ def compress_sequence(sequence):
     zfile.close()
     yield buf.read()
 
-class GZipMiddleware(object):
+class GZipMiddleware(MiddlewareMixin):
     """
     This middleware compresses content if the browser allows gzip compression.
     It sets the Vary header accordingly, so that caches will base their storage


### PR DESCRIPTION
Inheriting from MiddlewareMixin to add support for Django [new-style (1.11+) middleware](https://docs.djangoproject.com/en/2.0/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware).